### PR TITLE
Embed applicants github website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 config.env
 .DS_Store
 public/main.css
+config.json
 
 # Logs
 logs

--- a/model/github-page.js
+++ b/model/github-page.js
@@ -11,6 +11,7 @@ const getGithubPage = (url) => {
     .then((response) => {
       const githubObj = {};
       githubObj.success = true;
+      githubObj.url = options.uri;
       return githubObj;
     })
     .catch((err) => {

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -249,6 +249,17 @@ h1 {
   github section
 ***********************************************/
 
+.report-section__website {
+    margin: 0 auto;
+    margin-top: 1em;
+    border: none;
+    background-color: white;
+    width: 90%;
+    max-width: 1600px;
+}
+.report-section__website-link {
+    display: block;
+}
  .report-section__info-item {
    margin: 2vh 0;
  }
@@ -269,6 +280,10 @@ h1 {
 }
 
 @media only screen and (min-width: 600px) {
+
+  .report-section__website {
+    width: 100%;
+  }
   .report-section__calendar {
     max-width: 80vw;
     transition: all 1s;

--- a/tests/github.test.js
+++ b/tests/github.test.js
@@ -17,12 +17,13 @@ tape('getGithubPage with status code 404', (t) => {
 });
 
 tape('getGithubPage with status code 200', (t) => {
-  const url = 'https://dangerdak.github.io/effectivealtruism/';
+  const url = 'https://dangerdak.github.io/effectivealtruism';
   nock('https://dangerdak.github.io')
     .get('/effectivealtruism')
     .reply(200);
   getGithubPage(url)
     .then((githubObj) => {
+      t.equal(githubObj.url, url,  'Returns object with correct url value');
       t.ok(githubObj.success, 'Returns object with success true');
       t.end();
     });

--- a/views/partials/github.hbs
+++ b/views/partials/github.hbs
@@ -3,6 +3,8 @@
   <ul class="report-section__list report-section__banner">
     {{>githubSummary}}
   </ul>
+  <iframe class="report-section__website" width="320px" height="480px" src="{{githubPage.url}}"></iframe>
+  <a href="{{githubPage.url}}" class="report-section__website-link">Go to site</a>
   <ul>
      {{#if githubCommits.success}}
     <li class="report-section__info-item">


### PR DESCRIPTION
#62 Uses an iframe to embed applicants website in the github section.

Also adds a link to their site.