### PR TITLE
Normalise github urls with https not http and update tests accordingly

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,13 @@
     "github-calendar": "^1.1.12",
     "google-spreadsheet": "^2.0.4",
     "hbs": "~4.0.1",
+    "humanize-url": "^1.0.1",
     "morgan": "~1.8.1",
     "node-sass": "^4.5.3",
     "normalize-url": "^1.9.1",
     "pg": "^7.3.0",
     "pg-promise": "^6.5.1",
+    "prepend-http": "^2.0.0",
     "request": "^2.81.0",
     "request-promise-native": "^1.0.4",
     "serve-favicon": "~2.4.2"

--- a/routes/scrape-links.js
+++ b/routes/scrape-links.js
@@ -1,5 +1,7 @@
 const rp = require('request-promise-native');
 const normalizeUrl = require('normalize-url');
+const prependHttps = require('prepend-http');
+const humanizeUrl = require('humanize-url');
 
 const getGithubLink = (htmlString) => {
   const regEx = /github.com\/([\w-]*)/;
@@ -19,8 +21,15 @@ const getCodewarsLink = (htmlString) => {
   return cwHandle ? cwHandle[1] : null;
 };
 
+const formatUrl = (url) => {
+  if (url.includes('github')) {
+    return prependHttps(humanizeUrl(url), { https: true });
+  }
+  return normalizeUrl(url);
+};
+
 const scrapeLinks = (req, res) => {
-  const url = req.query.githubPage ? normalizeUrl(req.query.githubPage) : '';
+  const url = req.query.githubPage ? formatUrl(req.query.githubPage) : '';
   return rp(url)
     .then((htmlString) => {
       const githubScrape = {

--- a/tests/scrape-links.test.js
+++ b/tests/scrape-links.test.js
@@ -5,7 +5,7 @@ const nock = require('nock');
 const app = require('../app');
 
 test('Test /scrape-links endpoint with invalid URL', (t) => {
-  nock('http://faccer.github.io')
+  nock('https://faccer.github.io')
     .get('/')
     .reply(404, {
       status: 404,
@@ -24,7 +24,7 @@ test('Test /scrape-links endpoint with invalid URL', (t) => {
 });
 
 test('Test /scrape-links endpoint with valid URL', (t) => {
-  nock('http://validuser.github.io')
+  nock('https://validuser.github.io')
     .get('/')
     .reply(200, 'github.com/usernamegh freecodecamp.org/usernamefcc codewars.com/users/usernamecw');
 
@@ -34,7 +34,7 @@ test('Test /scrape-links endpoint with valid URL', (t) => {
     .expect('Content-Type', /json/)
     .end((err, res) => {
       t.same(res.statusCode, 200, 'Status code is 200');
-      t.ok(res.text.includes('value="http://validuser.github.io"'), 'Html form populates with Github page url value');
+      t.ok(res.text.includes('value="https://validuser.github.io"'), 'Html form populates with Github page url value');
       t.ok(res.text.includes('value="usernamefcc"'), 'Html form populates with freeCodeCamp username value');
       t.ok(res.text.includes('value="usernamecw"'), 'Html form populates with Codewars username value');
       t.ok(res.text.includes('value="usernamegh"'), 'Html form populates with Github username value');


### PR DESCRIPTION
#88 
This is a bug fix for  the 'fetching github commit counts failed' error occurring when it shouldn't.

The bug could previously by triggered by inputting ```ameliejyc.github.io``` or another github pages url without 'https'.
This url was transformed by ```normalizeUrl``` in the ```scrape-links.js``` module to have 'http' prepended.
When fetching the github commit count, this url was passed to the ```github-commits-api.js``` module; the ```getRepoName``` function removed 'https' from the url, but not 'http', so if the url was prepended with 'http' this would also be treated as part of the repo name, causing the api call for commit counts to fail.

This fix changes the url normalisation in ```scrape-links.js``` to prepend 'https' to github urls, rather than 'http'. I think this makes sense because all new github pages urls will be 'https'. It was incorrect to prepend 'http', it only worked because github silently redirects. Non github pages urls will be treated the same as before and will have 'http' prepended if 'http' or 'https' are not already present.

Non github pages urls will still result in the 'fetching github commit count failed' error because there is no way of extracting the repo name from the url.
