### PR TITLE
Put github oauth client id in environment variable

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -6,7 +6,7 @@ const scrapeLinks = require('./scrape-links');
 const { githubAuth } = require('./github-auth');
 
 const login = (req, res) => {
-  res.render('login');
+  res.render('login', { clientId: process.env.CLIENT_ID });
 };
 
 const links = (req, res) => {

--- a/views/login.hbs
+++ b/views/login.hbs
@@ -4,7 +4,7 @@
     <p class="login__info">Use prereqCheck to get a quick overview of applicants' completion and quality of the Founders and Coders prerequisites.</p>
     <form action="http://github.com/login/oauth/authorize?scope=read:org" method="GET">
         <input type="hidden" name="scope" value="read:org">
-        <input type="hidden" name="client_id" value="79fa1c93ddb2c874bc1d">
+        <input type="hidden" name="client_id" value="{{ clientId }}">
         <button type="submit" class="login__button">Sign in with GitHub</button>
     </form>
 </section>


### PR DESCRIPTION
#91 
We need a different github oauth app for dev environment and deployment so that the callback url can be localhost for dev, and heroku for deployment.
Previously client id (required by github's oauth flow) was hardcoded in the login html. With this PR it is instead made an environment variable.

Note that:
- devs will need to have the client id in their local config.json
- I have made another github oauth app (callback heroku) and applied to transfer it to the founders and coders organisation; transfer is currently pending. I've set the new client id and client secret as environment variables on heroku, so once this PR is merged to master the heroku app should work.