### PR TITLE
#98: fix authentication issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ config.json
 admin.json
 coverage.lcov
 key.txt
+logs.txt
 
 # Logs
 logs

--- a/routes/github-auth.js
+++ b/routes/github-auth.js
@@ -57,6 +57,13 @@ const githubAuth = (req, res) => {
       })
       .then((userTeams) => {
         req.session.isInTeam = isInTeam(userTeams);
+        console.log(`
+          User ${req.session.user} succesfully logged in.
+          \n ${req.session.user} isInTeam: ${req.session.isInTeam}.
+          \n User teams github response: ${JSON.stringify(userTeams)}
+          \n process.env.AUTHORISED_TEAM_NAME: ${process.env.AUTHORISED_TEAM_NAME}
+          \n JSON.parse(process.env.AUTHORISED_TEAM_ID): ${JSON.parse(process.env.AUTHORISED_TEAM_ID)}
+        `);
         res.redirect('/links');
       })
       .catch((err) => {

--- a/routes/github-auth.js
+++ b/routes/github-auth.js
@@ -15,7 +15,7 @@ const getUserData = (token) => {
   return rp(options);
 };
 
-const getUserTeams = (token) => {
+const getAdminTeamMembers = (token) => {
   const options = {
     uri: `https://api.github.com/teams/${process.env.AUTHORISED_TEAM_ID}/members`,
     headers: {
@@ -55,19 +55,15 @@ const githubAuth = (req, res) => {
       })
       .then((userData) => {
         req.session.user = userData.login;
-        return getUserTeams(req.session.token);
+        return getAdminTeamMembers(req.session.token);
       })
       .then((response) => {
         if (response.statusCode === 200) {
+          // if user is able to retrieve team they are probably a member, but check anyway
           req.session.isInTeam = isInTeam(response.body, req.session.user);
         } else {
           req.session.isInTeam = false;
         }
-        console.log(`
--          User ${req.session.user} succesfully logged in.
--          \n ${req.session.user} isInTeam: ${req.session.isInTeam}.
--          \n Get team members github response: ${response}
--        `);
         res.redirect('/links');
       })
       .catch((err) => {

--- a/routes/report.js
+++ b/routes/report.js
@@ -9,11 +9,6 @@ const isValidRequest = require('./validate-request');
 
 const displayReport = (req, res) => {
   if (!isValidRequest(req.session, req.query)) {
-    console.log(`
-      Redirecting session user ${req.session.user} because isValidRequest is falsy. 
-      \nRequest github handle: ${req.query.ghHandle}
-      \nRequest isInTeam: ${req.session.isInTeam}
-      `);
     return res.redirect('/links');
   }
   const { githubPage, fccHandle, cwHandle, ghHandle } = req.query;

--- a/routes/report.js
+++ b/routes/report.js
@@ -9,6 +9,11 @@ const isValidRequest = require('./validate-request');
 
 const displayReport = (req, res) => {
   if (!isValidRequest(req.session, req.query)) {
+    console.log(`
+      Redirecting session user ${req.session.user} because isValidRequest is falsy. 
+      \nRequest github handle: ${req.query.ghHandle}
+      \nRequest isInTeam: ${req.session.isInTeam}
+      `);
     return res.redirect('/links');
   }
   const { githubPage, fccHandle, cwHandle, ghHandle } = req.query;

--- a/tests/github-auth-route.test.js
+++ b/tests/github-auth-route.test.js
@@ -4,34 +4,25 @@ const request = require('supertest');
 const app = require('../app');
 const { isInTeam } = require('../routes/github-auth');
 
-const notInTeamData = [
+const teamMembersArray = [
   {
-    name: 'test-team-1',
-    id: 9898,
+    login: 'lucy-in-the-sky',
   },
   {
-    name: 'test-team-2',
-    id: 878783,
-  },
-];
-const isInTeamData = [
-  {
-    name: 'test-team-1',
-    id: 9898,
-  },
-  {
-    name: process.env.AUTHORISED_TEAM_NAME,
-    id: JSON.parse(process.env.AUTHORISED_TEAM_ID),
+    login: 'lucy-lu',
   },
 ];
 
+const isInTeamUser = 'lucy-lu';
+const notInTeamUser = 'lucy';
+
 tape('Test isInTeam pure function', (t) => {
-  t.equal(isInTeam(isInTeamData), true, 'If user is in the team should return true');
-  t.equal(isInTeam(notInTeamData), false, 'If user is not in the team should return false');
+  t.equal(isInTeam(teamMembersArray, isInTeamUser), true, 'If user is in the team should return true');
+  t.equal(isInTeam(teamMembersArray, notInTeamUser), false, 'If user is not in the team should return false');
   t.end();
 });
 
-tape('Test githubAuth: success case', (t) => {
+tape('Test githubAuth: success case for non-team member', (t) => {
   nock('https://github.com/login/oauth/access_token')
     .get(/.*/)
     .reply(200, { access_token: 'token' });
@@ -42,7 +33,7 @@ tape('Test githubAuth: success case', (t) => {
 
   nock('https://api.github.com/teams')
     .get(/.*/)
-    .reply(200, [{ name: 'wrong-team', id: 0000, }]);
+    .reply(400);
 
   request(app)
     .get('/auth?code=3aa491426dc2f4130a6b')


### PR DESCRIPTION
Fixes #98 
**Commits and branch name erroneously reference #99 , should reference #98.**

This PR:
- changes authentication logic and fixes problem detailed in #98 
- updates tests as necessary, and improves coverage by adding integration tests covering cases of users requesting the report page when they do/don't have team privileges
- removes some unneeded status code `expect`s in integration tests